### PR TITLE
Nodeのバージョンを指定する

### DIFF
--- a/.github/workflows/azure-static-web-apps-yellow-rock-027ed8200.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-rock-027ed8200.yml
@@ -21,6 +21,8 @@ jobs:
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
+        env:
+          AZURE_FUNCTIONS_API_HOST: ${{ secrets.AZURE_FUNCTIONS_API_HOST }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_YELLOW_ROCK_027ED8200 }}
           repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)

--- a/.github/workflows/azure-static-web-apps-yellow-rock-027ed8200.yml
+++ b/.github/workflows/azure-static-web-apps-yellow-rock-027ed8200.yml
@@ -29,7 +29,7 @@ jobs:
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
           app_location: "/" # App source code path
           api_location: "/api" # Api source code path - optional
-          app_artifact_location: "/dist" # Built app content directory - optional
+          app_artifact_location: "dist" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:

--- a/build.js
+++ b/build.js
@@ -1,6 +1,7 @@
 // https://qiita.com/olt/items/3e3840db050414cde0ed
 const { argv } = require("process");
 const { build } = require("esbuild");
+const fs = require("fs");
 const path = require("path");
 
 const options = {
@@ -19,7 +20,24 @@ const options = {
   tsconfig: path.resolve(__dirname, "tsconfig.json"),
 };
 
-build(options).catch((err) => {
-  process.stderr.write(err.stderr);
-  process.exit(1);
-});
+build(options)
+  .then(
+    () =>
+      new Promise((resolve, reject) =>
+        fs.copyFile(
+          path.resolve(__dirname, "index.html"),
+          path.resolve(__dirname, "dist", "index.html"),
+          (err) => {
+            if (err) {
+              reject(err);
+            } else {
+              resolve();
+            }
+          }
+        )
+      )
+  )
+  .catch((err) => {
+    process.stderr.write(err.stderr);
+    process.exit(1);
+  });

--- a/index.html
+++ b/index.html
@@ -6,6 +6,6 @@
   </head>
   <body>
     <div id="root" />
-    <script src="./dist/index.js"></script>
+    <script src="./index.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "main": "index.js",
   "license": "MIT",
+  "engines": {
+    "node": "14.x"
+  },
   "scripts": {
     "build": "npm run build/prod",
     "build/dev": "node build.js development",


### PR DESCRIPTION
Azure Static Web Appsのビルドの役割をしているOryxがいい感じにビルド対象の言語とかを調べてくれるんだけど、Node.jsのプロジェクトを指定した時Node 12が使われた。
Null合体演算子とか使いたいので最新のNode 14を使って欲しい。
ということで、package.jsonのennginesに"node": "14.x"を記述した。

またindex.htmlとかがdistに必要だったので、copyのスクリプトも書いた。

envはSecretsからよしなに読めるのでシュッと設定しちゃおう。